### PR TITLE
switch to variable size stable structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "stable-fs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitflags",
  "ciborium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable-fs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A Simple File system implementing WASI endpoints and using the stable structures of the Internet Computer"
 keywords = ["ic", "internet-computer", "file-system"]
@@ -9,7 +9,7 @@ license = "MIT"
 [dependencies]
 bitflags = "2.3.1"
 ic-cdk = "0.12.1"
-ic-stable-structures = "0.6.2"
+ic-stable-structures = "0.6"
 serde = "1.0.164"
 serde_bytes = "0.11"
 ciborium = "0.2.1"

--- a/src/runtime/dir.rs
+++ b/src/runtime/dir.rs
@@ -49,7 +49,8 @@ impl Dir {
             Err(err) => return Err(err),
         }
 
-        let (node, _leaf_name) = create_path(self.node, path, Some(FileType::Directory), ctime, storage)?;
+        let (node, _leaf_name) =
+            create_path(self.node, path, Some(FileType::Directory), ctime, storage)?;
 
         Self::new(node, stat, storage)
     }
@@ -447,8 +448,6 @@ mod tests {
         assert!(res.is_ok());
     }
 
-
-
     #[test]
     fn rename_a_file_using_path_with_subfolders() {
         let mut fs = test_fs();
@@ -527,8 +526,6 @@ mod tests {
         assert!(res.is_ok());
     }
 
-
-
     #[test]
     fn rename_a_folder_using_subfolders() {
         let mut fs = test_fs();
@@ -561,7 +558,5 @@ mod tests {
         let res = fs.open_or_create(dir2_fd, "dir3", FdStat::default(), OpenFlags::empty(), 123);
 
         assert!(res.is_ok());
-
-
-    }    
+    }
 }

--- a/src/runtime/file.rs
+++ b/src/runtime/file.rs
@@ -107,7 +107,6 @@ impl File {
         buf: &mut [u8],
         storage: &mut dyn Storage,
     ) -> Result<FileSize, Error> {
-
         if buf.is_empty() {
             return Ok(0 as FileSize);
         }
@@ -117,9 +116,8 @@ impl File {
         let chunk_infos = get_chunk_infos(offset, end);
 
         let mut read_size = 0;
-        
-        for chunk in chunk_infos.into_iter() {
 
+        for chunk in chunk_infos.into_iter() {
             storage.read_filechunk(
                 self.node,
                 chunk.index,

--- a/src/runtime/structure_helpers.rs
+++ b/src/runtime/structure_helpers.rs
@@ -20,7 +20,6 @@ fn find_node_with_index(
     path: &str,
     storage: &dyn Storage,
 ) -> Result<EntryFindResult, Error> {
-    
     let parts = path.split('/');
 
     let mut parent_dir_node = parent_dir_node;
@@ -82,8 +81,7 @@ pub fn create_hard_link(
     let ctime = metadata.times.created;
 
     //
-    let (dir_node, leaf_name) =
-        create_path(parent_dir_node, new_path, None, ctime, storage)?;
+    let (dir_node, leaf_name) = create_path(parent_dir_node, new_path, None, ctime, storage)?;
 
     // only allow creating a hardlink on a folder if it is a part of renaming and another link will be removed
     if !is_renaming && metadata.file_type == FileType::Directory {
@@ -97,7 +95,6 @@ pub fn create_hard_link(
 
     Ok(())
 }
-
 
 pub fn create_dir_entry(
     parent_dir_node: Node,
@@ -212,7 +209,8 @@ pub fn create_path<'a>(
 
         if let Some(leaf_type) = leaf_type {
             // create new folder
-            cur_node = create_dir_entry(parent_node, last_name.as_bytes(), leaf_type, storage, ctime)?;
+            cur_node =
+                create_dir_entry(parent_node, last_name.as_bytes(), leaf_type, storage, ctime)?;
         }
     }
 
@@ -376,7 +374,6 @@ pub fn rm_dir_entry(
 
     Ok((removed_dir_entry_node, removed_metadata))
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -58,7 +58,6 @@ pub struct Metadata {
     pub last_dir_entry: Option<DirEntryIndex>,
 }
 
-
 impl ic_stable_structures::Storable for Metadata {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
         let mut buf = vec![];

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -58,26 +58,11 @@ pub struct Metadata {
     pub last_dir_entry: Option<DirEntryIndex>,
 }
 
-// This value was obtained by printing `Storable::to_bytes().len()`,
-// which is 140 and rounding it up to 144.
-const MAX_META_SIZE: u32 = 144;
 
 impl ic_stable_structures::Storable for Metadata {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        let mut buf = vec![0u8; MAX_META_SIZE as usize];
-
-        unsafe { buf.set_len(0) }
-
+        let mut buf = vec![];
         ciborium::ser::into_writer(&self, &mut buf).unwrap();
-
-        unsafe { buf.set_len(MAX_META_SIZE as usize) }
-
-        assert!(
-            MAX_META_SIZE >= buf.len() as u32,
-            "Metadata size assertion fails: MAX_META_SIZE = {}, buf.len() = {}",
-            MAX_META_SIZE,
-            buf.len()
-        );
         std::borrow::Cow::Owned(buf)
     }
 
@@ -85,10 +70,7 @@ impl ic_stable_structures::Storable for Metadata {
         ciborium::de::from_reader(bytes.as_ref()).unwrap()
     }
 
-    const BOUND: Bound = Bound::Bounded {
-        max_size: MAX_META_SIZE,
-        is_fixed_size: true,
-    };
+    const BOUND: Bound = Bound::Unbounded;
 }
 
 // The type of a node.
@@ -199,26 +181,10 @@ pub struct DirEntry {
     pub prev_entry: Option<DirEntryIndex>,
 }
 
-// This value was obtained by printing `DirEntry::to_bytes().len()`,
-// which is 308 and rounding it up to 320.
-pub const MAX_DIR_ENTRY_SIZE: u32 = 320;
-
 impl ic_stable_structures::Storable for DirEntry {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        let mut buf = vec![0; MAX_DIR_ENTRY_SIZE as usize];
-
-        unsafe { buf.set_len(0) }
-
+        let mut buf = vec![];
         ciborium::ser::into_writer(&self, &mut buf).unwrap();
-
-        unsafe { buf.set_len(MAX_DIR_ENTRY_SIZE as usize) }
-
-        assert!(
-            MAX_DIR_ENTRY_SIZE >= buf.len() as u32,
-            "DirEntry size assertion fails: MAX_DIR_ENTRY_SIZE = {}, buf.len() = {}",
-            MAX_DIR_ENTRY_SIZE,
-            buf.len()
-        );
         std::borrow::Cow::Owned(buf)
     }
 
@@ -226,9 +192,5 @@ impl ic_stable_structures::Storable for DirEntry {
         ciborium::de::from_reader(bytes.as_ref()).unwrap()
     }
 
-    const BOUND: ic_stable_structures::storable::Bound =
-        ic_stable_structures::storable::Bound::Bounded {
-            max_size: MAX_DIR_ENTRY_SIZE,
-            is_fixed_size: true,
-        };
+    const BOUND: ic_stable_structures::storable::Bound = Bound::Unbounded;
 }


### PR DESCRIPTION
this fixes the issue #2 

The reserved max metadata size was not large enough for certain examples.

solution: changed to variable length metadata, which fixes the problem but breaks backward compatibility.
The version number was increased to 0.3.

